### PR TITLE
Bugfix/bulletkill exp bug

### DIFF
--- a/src/entity/EnemyShip.java
+++ b/src/entity/EnemyShip.java
@@ -1,6 +1,7 @@
 package entity;
 
 import java.awt.Color;
+import java.util.ArrayList;
 import java.util.Random;
 
 import engine.Cooldown;
@@ -134,6 +135,22 @@ public class EnemyShip extends Entity {
 
 		double levelMultiplier = Math.pow(1.05, gameState.getGameLevel() - 1);
 		this.health = baseHealth * levelMultiplier;
+	}
+
+	private void initializeExp(GameState gameState, EnemyType enemyType) {
+		// base exp for enemies.
+		// index 0: GRUNT, index 1: ELITE, index 2: CHAMPION
+		final int[] BASE_EXP = {10,20,30};
+
+		double levelMultiplier = Math.pow(1.05, gameState.getGameLevel() - 1);
+		switch (enemyType){
+			case GRUNT: this.expValue = BASE_EXP[0] * (int)levelMultiplier;
+				break;
+			case ELITE: this.expValue = BASE_EXP[1] * (int)levelMultiplier;
+				break;
+			case CHAMPION: this.expValue = BASE_EXP[2] * (int)levelMultiplier;
+				break;
+		}
 	}
 
 	/**

--- a/src/entity/EnemyShip.java
+++ b/src/entity/EnemyShip.java
@@ -88,36 +88,31 @@ public class EnemyShip extends Entity {
 		this.animationCooldown = Core.getCooldown(500);
 		this.isDestroyed = false;
 		initializeHealth(gameState, this.enemyType);
+		initializeExp(gameState, this.enemyType);
 
 		switch (this.spriteType) {
 		case EnemyShipA1:
 		case EnemyShipA2:
 			this.pointValue = (int) (A_TYPE_POINTS+(gameState.getGameLevel()*0.1)+Core.getLevelSetting());
-			this.expValue = (int) (A_TYPE_EXP+(gameState.getGameLevel()*0.1)+Core.getLevelSetting());
 			break;
 		case EnemyShipB1:
 		case EnemyShipB2:
 			this.pointValue = (int) (B_TYPE_POINTS+(gameState.getGameLevel()*0.1)+Core.getLevelSetting());
-			this.expValue = (int) (B_TYPE_EXP+(gameState.getGameLevel()*0.1)+Core.getLevelSetting());
 			break;
 		case EnemyShipC1:
 		case EnemyShipC2:
 			this.pointValue = (int) (C_TYPE_POINTS+(gameState.getGameLevel()*0.1)+Core.getLevelSetting());
-			this.expValue = (int) (C_TYPE_EXP+(gameState.getGameLevel()*0.1)+Core.getLevelSetting());
 			break;
 		case EnemyShipD1:
 		case EnemyShipD2:
 			this.pointValue = D_TYPE_POINTS;
-			this.expValue = (int) (D_TYPE_EXP+(gameState.getGameLevel()*0.1)+Core.getLevelSetting());
 			break;
 		case EnemyShipE1:
 		case EnemyShipE2:
 			this.pointValue = E_TYPE_POINTS;
-			this.expValue = (int) (E_TYPE_EXP+(gameState.getGameLevel()*0.1)+Core.getLevelSetting());
 			break;
 		case EnemyShipF1:
 			this.pointValue = F_TYPE_POINTS;
-			this.expValue = (int) (F_TYPE_EXP+(gameState.getGameLevel()*0.1)+Core.getLevelSetting());
 			break;
 		default:
 			this.pointValue = 0;
@@ -137,6 +132,11 @@ public class EnemyShip extends Entity {
 		this.health = baseHealth * levelMultiplier;
 	}
 
+	/**
+	 * Assign base exp for each enemy types, considering level scaling.
+	 * @param gameState gameState instance
+	 * @param enemyType enemy type
+	 * */
 	private void initializeExp(GameState gameState, EnemyType enemyType) {
 		// base exp for enemies.
 		// index 0: GRUNT, index 1: ELITE, index 2: CHAMPION

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -963,9 +963,7 @@ public class GameScreen extends Screen implements Callable<GameState> {
 				// only in case of bomb item, itemResult is not null
 				if (itemResult != null) {
 					this.gameState.setScore(this.gameState.getScore() + itemResult.getFirst());
-//							this.gameState.setExp(this.gameState.getExp() + itemResult.get(1));
 					this.gameState.getPlayerShip().increasePlayerExp(itemResult.get(1));
-					logger.info("You got this exp by bomb: " + this.gameState.getExp());
 					this.gameState.setShipsDestroyed(this.gameState.getShipsDestroyed() + itemResult.getLast());
 				}
 			}
@@ -1012,7 +1010,6 @@ public class GameScreen extends Screen implements Callable<GameState> {
 		// if the enemy dies, both the combo and score increase.
 		this.gameState.setScore(this.gameState.getScore() + Score.comboScore(this.enemyShipFormation.getPointValue(), this.gameState.getCombo()));
 		this.gameState.getPlayerShip().increasePlayerExp(this.enemyShipFormation.getExpValue());
-		logger.info("You got this exp by shooing bullets: " + this.gameState.getExp());
 		this.gameState.setShipsDestroyed(this.gameState.getShipsDestroyed() + this.enemyShipFormation.getDistroyedship());
 		this.gameState.setCombo(this.gameState.getCombo() + 1);
 		this.gameState.setHitBullets(this.gameState.getHitBullets() + 1);


### PR DESCRIPTION
EnemyShip에서 각 enemyType별로 Expvalue가 할당되지 않은 것이 원인이었습니다.
* 해당 원인을 initializeExp() 메서드를 새로 만들어 구현하였고, 
* 기존 constructor에서 불필요하게 존재하던 expValue 할당 line들을 모두 지웠습니다.

그 결과, 아래 로그에서 보이는 바와 같이 경험치가 잘 획득되는 것을 확인할 수 있었습니다.

![스크린샷 2024-11-22 22 32 26](https://github.com/user-attachments/assets/8560a872-5b30-4142-beeb-0b306f65d9d2)
![스크린샷 2024-11-22 22 32 51](https://github.com/user-attachments/assets/b9f4b559-de9b-43de-9375-3ac3f67d2ae5)

CSE2024SDP-200

