### PR TITLE
!hotfix: apply volume control to background musics

### DIFF
--- a/src/engine/SoundManager.java
+++ b/src/engine/SoundManager.java
@@ -185,6 +185,17 @@ public class SoundManager {
         }
       }
     }
+    // Apply to soundClips (including background music)
+    for (Clip clip : soundClips.values()) {
+        try {
+          FloatControl volumeControl =
+                  (FloatControl) clip.getControl(FloatControl.Type.MASTER_GAIN);
+          volumeControl.setValue(newVolume);
+        } catch (IllegalArgumentException e) {
+          logger.warning("Failed to set volume: " + e.getMessage());
+        }
+    }
+
   }
 
   /**


### PR DESCRIPTION
Hotfix: 볼륨조절이 배경음악에 적용되지 않던 문제 해결하였습니다.
---
변경내용: SoundManager.setVolume()에서 Bgm이 관리되는 soundClip에도 볼륨설정이 적용되도록 코드 추가.
---
CSE2024SDP-237